### PR TITLE
refactor: add export functionality for timesheet data in various formats

### DIFF
--- a/timeharbourapp/app/dashboard/settings/timesheet/page.tsx
+++ b/timeharbourapp/app/dashboard/settings/timesheet/page.tsx
@@ -305,9 +305,9 @@ export default function TimesheetPage() {
                   className="absolute right-0 mt-1 w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg z-30"
                 >
                   {([
-                    { label: 'CSV (.csv)', handler: () => exportToCSV(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
-                    { label: 'Plain Text (.txt)', handler: () => exportToText(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
-                    { label: 'HTML (print / PDF)', handler: () => exportToHTML(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
+                    { label: 'CSV (.csv)', handler: () => exportToCSV(groupedByDay as TimesheetDayGroup[], totalMs, dateRange).catch(console.error) },
+                    { label: 'Plain Text (.txt)', handler: () => exportToText(groupedByDay as TimesheetDayGroup[], totalMs, dateRange).catch(console.error) },
+                    { label: 'HTML (print / PDF)', handler: () => exportToHTML(groupedByDay as TimesheetDayGroup[], totalMs, dateRange).catch(console.error) },
                   ] as const).map(({ label, handler }) => (
                     <button
                       key={label}

--- a/timeharbourapp/app/dashboard/settings/timesheet/page.tsx
+++ b/timeharbourapp/app/dashboard/settings/timesheet/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { DateRangePickerWithPresets } from '@/components/DateRangePickerWithPresets';
 import { DateTime } from 'luxon';
@@ -8,8 +8,9 @@ import { dateFilterPresets, resolveRange, type LuxonDateRange } from '@/lib/date
 import { Activity, fetchActivitiesByDateRange, getTimesheetTotals, TimesheetDayTotal } from '@/TimeharborAPI/dashboard';
 import { formatDurationMs } from '@/lib/formatDuration';
 import {
-  Clock, Calendar, Pencil, X, Check, Plus, Trash2, ChevronDown, ChevronRight,
+  Clock, Calendar, Pencil, X, Check, Plus, Trash2, ChevronDown, ChevronRight, Download,
 } from 'lucide-react';
+import { exportToCSV, exportToText, exportToHTML, type TimesheetDayGroup } from '@/lib/timesheetExport';
 import { useRefresh } from '../../../../contexts/RefreshContext';
 import {
   Button, Input, Select, Badge,
@@ -84,6 +85,21 @@ export default function TimesheetPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<EditState | null>(null);
   const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  /* ── export state ───────────────────────────────────── */
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const exportMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!showExportMenu) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
+        setShowExportMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showExportMenu]);
 
   /* ── data fetching ──────────────────────────────────── */
   useEffect(() => {
@@ -270,6 +286,43 @@ export default function TimesheetPage() {
                 {formatDurationMs(totalMs)}
               </span>
             </div>
+            {/* Export dropdown */}
+            <div ref={exportMenuRef} className="relative">
+              <Button
+                variant="outline"
+                onClick={() => setShowExportMenu(prev => !prev)}
+                disabled={activities.length === 0}
+                aria-label="Export timesheet"
+                aria-haspopup="menu"
+                aria-expanded={showExportMenu}
+              >
+                <Download className="w-4 h-4" />
+                <span className="hidden sm:inline">Export</span>
+              </Button>
+              {showExportMenu && (
+                <div
+                  role="menu"
+                  className="absolute right-0 mt-1 w-48 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg z-30"
+                >
+                  {([
+                    { label: 'CSV (.csv)', handler: () => exportToCSV(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
+                    { label: 'Plain Text (.txt)', handler: () => exportToText(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
+                    { label: 'HTML (print / PDF)', handler: () => exportToHTML(groupedByDay as TimesheetDayGroup[], totalMs, dateRange) },
+                  ] as const).map(({ label, handler }) => (
+                    <button
+                      key={label}
+                      role="menuitem"
+                      type="button"
+                      onClick={() => { handler(); setShowExportMenu(false); }}
+                      className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700/60 transition-colors first:rounded-t-lg last:rounded-b-lg"
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
             <Button onClick={addEntry} aria-label="Add timesheet entry">
               <Plus className="w-4 h-4" />
               <span className="hidden sm:inline">Add Entry</span>

--- a/timeharbourapp/ios/App/App/Info.plist
+++ b/timeharbourapp/ios/App/App/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/timeharbourapp/lib/timesheetExport.ts
+++ b/timeharbourapp/lib/timesheetExport.ts
@@ -1,0 +1,308 @@
+import { DateTime } from 'luxon';
+import { formatDurationMs } from './formatDuration';
+import type { Activity, TimesheetDayTotal } from '@/TimeharborAPI/dashboard';
+
+// ── types ──────────────────────────────────────────────────────────────────────
+
+export interface TimesheetDayGroup {
+  dateKey: string;
+  dayName: string;
+  fullDate: string;
+  activities: Activity[];
+  totalMs: number;
+}
+
+interface ExportRow {
+  date: string;
+  day: string;
+  startTime: string;
+  endTime: string;
+  duration: string;
+  ticket: string;
+  description: string;
+  flag: string;
+  status: string;
+}
+
+// ── constants ──────────────────────────────────────────────────────────────────
+
+const FLAG_LABELS: Record<string, string> = {
+  none: '',
+  billable: 'Billable',
+  'non-billable': 'Non-Billable',
+  overtime: 'Overtime',
+  holiday: 'Holiday',
+};
+
+// ── shared helpers ─────────────────────────────────────────────────────────────
+
+function fmtTime(iso: string): string {
+  return DateTime.fromISO(iso).toFormat('h:mm a');
+}
+
+function buildRows(groups: TimesheetDayGroup[]): ExportRow[] {
+  const rows: ExportRow[] = [];
+  for (const group of groups) {
+    for (const a of group.activities) {
+      rows.push({
+        date: group.dateKey,
+        day: group.dayName,
+        startTime: fmtTime(a.startTime),
+        endTime: a.endTime ? fmtTime(a.endTime) : '',
+        duration: a.durationMs ? formatDurationMs(a.durationMs) : '',
+        ticket: a.subtitle || '',
+        description: a.description || a.title || '',
+        flag: FLAG_LABELS[a.metadata?.flag as string] ?? (a.metadata?.flag as string) ?? '',
+        status: a.status || '',
+      });
+    }
+  }
+  return rows;
+}
+
+function triggerDownload(filename: string, mimeType: string, content: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function buildFilename(
+  ext: string,
+  dateRange: { from: DateTime; to: DateTime },
+): string {
+  const from = dateRange.from.toFormat('yyyy-MM-dd');
+  const to = dateRange.to.toFormat('yyyy-MM-dd');
+  return `timesheet-${from}_${to}.${ext}`;
+}
+
+function headerLine(
+  dateRange: { from: DateTime; to: DateTime },
+  totalMs: number,
+): { period: string; exported: string; total: string } {
+  return {
+    period: `${dateRange.from.toFormat('MMM d, yyyy')} – ${dateRange.to.toFormat('MMM d, yyyy')}`,
+    exported: DateTime.now().toFormat('MMM d, yyyy h:mm a'),
+    total: formatDurationMs(totalMs),
+  };
+}
+
+// ── CSV ────────────────────────────────────────────────────────────────────────
+
+function csvEscape(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsvRow(cells: string[]): string {
+  return cells.map(csvEscape).join(',');
+}
+
+export function exportToCSV(
+  groups: TimesheetDayGroup[],
+  totalMs: number,
+  dateRange: { from: DateTime; to: DateTime },
+): void {
+  const { period, exported, total } = headerLine(dateRange, totalMs);
+  const rows = buildRows(groups);
+
+  const lines: string[] = [];
+
+  // Report header block
+  lines.push('TIMESHEET REPORT');
+  lines.push(`Period,${csvEscape(period)}`);
+  lines.push(`Exported,${csvEscape(exported)}`);
+  lines.push(`Total Time,${csvEscape(total)}`);
+  lines.push('');
+
+  // Day summary section
+  lines.push('DAY SUMMARY');
+  lines.push(toCsvRow(['Date', 'Day', 'Total Time']));
+  for (const g of groups) {
+    lines.push(toCsvRow([g.dateKey, g.dayName, formatDurationMs(g.totalMs)]));
+  }
+  lines.push('');
+
+  // Entry detail section
+  lines.push('ENTRY DETAIL');
+  lines.push(toCsvRow(['Date', 'Day', 'Start Time', 'End Time', 'Duration', 'Ticket', 'Description', 'Flag', 'Status']));
+  for (const r of rows) {
+    lines.push(toCsvRow([r.date, r.day, r.startTime, r.endTime, r.duration, r.ticket, r.description, r.flag, r.status]));
+  }
+
+  triggerDownload(buildFilename('csv', dateRange), 'text/csv;charset=utf-8;', lines.join('\n'));
+}
+
+// ── Plain Text ─────────────────────────────────────────────────────────────────
+
+function padRight(s: string, len: number): string {
+  return s.length >= len ? s : s + ' '.repeat(len - s.length);
+}
+
+export function exportToText(
+  groups: TimesheetDayGroup[],
+  totalMs: number,
+  dateRange: { from: DateTime; to: DateTime },
+): void {
+  const { period, exported, total } = headerLine(dateRange, totalMs);
+  const lines: string[] = [];
+
+  const separator = '─'.repeat(60);
+
+  lines.push('TIMESHEET REPORT');
+  lines.push(separator);
+  lines.push(`Period   : ${period}`);
+  lines.push(`Exported : ${exported}`);
+  lines.push(`Total    : ${total}`);
+  lines.push('');
+
+  for (const g of groups) {
+    lines.push(separator);
+    lines.push(`${g.dayName.toUpperCase()}, ${g.fullDate}  (${formatDurationMs(g.totalMs)})`);
+    lines.push(separator);
+
+    if (g.activities.length === 0) {
+      lines.push('  No entries');
+    } else {
+      const colW = { start: 10, end: 10, dur: 10, ticket: 18, flag: 14 };
+      const header =
+        `  ${padRight('Start', colW.start)}${padRight('End', colW.end)}${padRight('Duration', colW.dur)}${padRight('Ticket', colW.ticket)}${padRight('Flag', colW.flag)}Description`;
+      lines.push(header);
+      lines.push(`  ${'·'.repeat(header.length - 2)}`);
+
+      for (const a of g.activities) {
+        const flag = FLAG_LABELS[a.metadata?.flag as string] ?? '';
+        const dur = a.durationMs ? formatDurationMs(a.durationMs) : '';
+        const start = fmtTime(a.startTime);
+        const end = a.endTime ? fmtTime(a.endTime) : '';
+        const ticket = a.subtitle || '';
+        const desc = a.description || a.title || '';
+        lines.push(
+          `  ${padRight(start, colW.start)}${padRight(end, colW.end)}${padRight(dur, colW.dur)}${padRight(ticket, colW.ticket)}${padRight(flag, colW.flag)}${desc}`,
+        );
+      }
+    }
+    lines.push('');
+  }
+
+  lines.push(separator);
+  lines.push(`TOTAL: ${total}`);
+  lines.push(separator);
+
+  triggerDownload(buildFilename('txt', dateRange), 'text/plain;charset=utf-8;', lines.join('\n'));
+}
+
+// ── HTML (print/PDF) ──────────────────────────────────────────────────────────
+
+export function exportToHTML(
+  groups: TimesheetDayGroup[],
+  totalMs: number,
+  dateRange: { from: DateTime; to: DateTime },
+): void {
+  const { period, exported, total } = headerLine(dateRange, totalMs);
+
+  const dayRows = groups
+    .map(g => `
+      <tr>
+        <td>${g.dateKey}</td>
+        <td>${g.dayName}</td>
+        <td class="num">${formatDurationMs(g.totalMs)}</td>
+      </tr>`)
+    .join('');
+
+  const entryRows = buildRows(groups)
+    .map(r => `
+      <tr>
+        <td>${r.date}</td>
+        <td>${r.day}</td>
+        <td class="num">${r.startTime}</td>
+        <td class="num">${r.endTime}</td>
+        <td class="num">${r.duration}</td>
+        <td>${escapeHtml(r.ticket)}</td>
+        <td>${escapeHtml(r.description)}</td>
+        <td>${escapeHtml(r.flag)}</td>
+        <td>${escapeHtml(r.status)}</td>
+      </tr>`)
+    .join('');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Timesheet Report – ${period}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; font-size: 13px; color: #111; margin: 32px; }
+    h1 { font-size: 20px; margin: 0 0 4px; }
+    .meta { color: #555; font-size: 12px; margin-bottom: 24px; }
+    h2 { font-size: 14px; margin: 28px 0 8px; border-bottom: 2px solid #1a8aff; padding-bottom: 4px; color: #1a8aff; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 8px; }
+    th { background: #f0f4f8; text-align: left; padding: 6px 10px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+    td { padding: 5px 10px; border-bottom: 1px solid #e8ecf0; }
+    tr:last-child td { border-bottom: none; }
+    .num { text-align: left; white-space: nowrap; }
+    .total-row { font-weight: bold; background: #f0f4f8; }
+    .footer { margin-top: 32px; font-size: 11px; color: #888; }
+    @media print {
+      body { margin: 16px; font-size: 11px; }
+      h2 { page-break-before: auto; }
+      table { page-break-inside: auto; }
+      tr { page-break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Timesheet Report</h1>
+  <div class="meta">
+    Period: <strong>${period}</strong> &nbsp;·&nbsp;
+    Total: <strong>${total}</strong> &nbsp;·&nbsp;
+    Exported: ${exported}
+  </div>
+
+  <h2>Day Summary</h2>
+  <table>
+    <thead>
+      <tr><th>Date</th><th>Day</th><th>Total Time</th></tr>
+    </thead>
+    <tbody>
+      ${dayRows}
+      <tr class="total-row"><td colspan="2">Total</td><td class="num">${total}</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Entry Detail</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th><th>Day</th><th>Start</th><th>End</th><th>Duration</th>
+        <th>Ticket</th><th>Description</th><th>Flag</th><th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${entryRows}
+    </tbody>
+  </table>
+
+  <div class="footer">Generated by TimeHarbor · ${exported}</div>
+</body>
+</html>`;
+
+  const win = window.open('', '_blank');
+  if (win) {
+    win.document.write(html);
+    win.document.close();
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/timeharbourapp/lib/timesheetExport.ts
+++ b/timeharbourapp/lib/timesheetExport.ts
@@ -60,8 +60,21 @@ function buildRows(groups: TimesheetDayGroup[]): ExportRow[] {
   return rows;
 }
 
-function triggerDownload(filename: string, mimeType: string, content: string): void {
+async function triggerDownload(filename: string, mimeType: string, content: string): Promise<void> {
   const blob = new Blob([content], { type: mimeType });
+
+  // On mobile (Capacitor / iOS / Android) the `download` attribute on anchors
+  // is ignored by WKWebView. Use the native share sheet via Web Share API instead,
+  // which lets the user email/message the file directly to their manager.
+  if (typeof navigator.share === 'function' && typeof navigator.canShare === 'function') {
+    const file = new File([blob], filename, { type: mimeType });
+    if (navigator.canShare({ files: [file] })) {
+      await navigator.share({ files: [file], title: 'Timesheet Export' });
+      return;
+    }
+  }
+
+  // Desktop fallback: trigger a browser download.
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -103,11 +116,11 @@ function toCsvRow(cells: string[]): string {
   return cells.map(csvEscape).join(',');
 }
 
-export function exportToCSV(
+export async function exportToCSV(
   groups: TimesheetDayGroup[],
   totalMs: number,
   dateRange: { from: DateTime; to: DateTime },
-): void {
+): Promise<void> {
   const { period, exported, total } = headerLine(dateRange, totalMs);
   const rows = buildRows(groups);
 
@@ -135,7 +148,7 @@ export function exportToCSV(
     lines.push(toCsvRow([r.date, r.day, r.startTime, r.endTime, r.duration, r.ticket, r.description, r.flag, r.status]));
   }
 
-  triggerDownload(buildFilename('csv', dateRange), 'text/csv;charset=utf-8;', lines.join('\n'));
+  await triggerDownload(buildFilename('csv', dateRange), 'text/csv;charset=utf-8;', lines.join('\n'));
 }
 
 // ── Plain Text ─────────────────────────────────────────────────────────────────
@@ -144,11 +157,11 @@ function padRight(s: string, len: number): string {
   return s.length >= len ? s : s + ' '.repeat(len - s.length);
 }
 
-export function exportToText(
+export async function exportToText(
   groups: TimesheetDayGroup[],
   totalMs: number,
   dateRange: { from: DateTime; to: DateTime },
-): void {
+): Promise<void> {
   const { period, exported, total } = headerLine(dateRange, totalMs);
   const lines: string[] = [];
 
@@ -194,16 +207,16 @@ export function exportToText(
   lines.push(`TOTAL: ${total}`);
   lines.push(separator);
 
-  triggerDownload(buildFilename('txt', dateRange), 'text/plain;charset=utf-8;', lines.join('\n'));
+  await triggerDownload(buildFilename('txt', dateRange), 'text/plain;charset=utf-8;', lines.join('\n'));
 }
 
 // ── HTML (print/PDF) ──────────────────────────────────────────────────────────
 
-export function exportToHTML(
+export async function exportToHTML(
   groups: TimesheetDayGroup[],
   totalMs: number,
   dateRange: { from: DateTime; to: DateTime },
-): void {
+): Promise<void> {
   const { period, exported, total } = headerLine(dateRange, totalMs);
 
   const dayRows = groups
@@ -292,6 +305,16 @@ export function exportToHTML(
 </body>
 </html>`;
 
+  // On mobile: share the HTML as a file via the native share sheet.
+  if (typeof navigator.share === 'function' && typeof navigator.canShare === 'function') {
+    const file = new File([new Blob([html], { type: 'text/html' })], buildFilename('html', dateRange), { type: 'text/html' });
+    if (navigator.canShare({ files: [file] })) {
+      await navigator.share({ files: [file], title: 'Timesheet Report' });
+      return;
+    }
+  }
+
+  // Desktop: open in a new tab so the user can Ctrl+P → Save as PDF.
   const win = window.open('', '_blank');
   if (win) {
     win.document.write(html);


### PR DESCRIPTION
This pull request adds a comprehensive timesheet export feature to the dashboard, allowing users to export their timesheet data in CSV, plain text, or HTML (print/PDF) formats. The export functionality is accessible via a new "Export" dropdown button in the timesheet page UI. Supporting logic and helpers for formatting and downloading the exported data are included in a new utility module.

**Timesheet export feature:**

* Added a new export dropdown menu to the timesheet dashboard page, enabling users to export timesheet data as CSV, plain text, or HTML (print/PDF) files. The menu is accessible via an "Export" button and closes automatically when clicking outside the menu. (`timeharbourapp/app/dashboard/settings/timesheet/page.tsx`) [[1]](diffhunk://#diff-f57ea0d6b6e3a16e1ddd4741336d9c0a6f556232f1f8bf9ae19fdf444789a1fdL3-R13) [[2]](diffhunk://#diff-f57ea0d6b6e3a16e1ddd4741336d9c0a6f556232f1f8bf9ae19fdf444789a1fdR89-R103) [[3]](diffhunk://#diff-f57ea0d6b6e3a16e1ddd4741336d9c0a6f556232f1f8bf9ae19fdf444789a1fdR289-R325)
* Implemented the export logic in a new module, providing functions to generate and download timesheet reports in multiple formats. The exports include day summaries and entry details, and are formatted for easy import, sharing, or printing. (`timeharbourapp/lib/timesheetExport.ts`)

**Other changes:**

* Updated iOS app configuration to declare usage of non-exempt encryption, as required by App Store policies. (`timeharbourapp/ios/App/App/Info.plist`)