### PR TITLE
feat: implement TimeHuddle connection functionality and update API ro…

### DIFF
--- a/timeharbourapp/TimeharborAPI/index.ts
+++ b/timeharbourapp/TimeharborAPI/index.ts
@@ -2,5 +2,6 @@ export * as identity from './identity';
 export * as tickets from './tickets';
 export * as dashboard from './dashboard';
 export * as projects from './projects';
+export * as timehuddle from './timehuddle';
 export { operationsLog } from './OperationsLog';
 export type { OperationCategory, OperationAction, OperationResult, OperationLogEntry } from './OperationsLog';

--- a/timeharbourapp/TimeharborAPI/timehuddle/index.ts
+++ b/timeharbourapp/TimeharborAPI/timehuddle/index.ts
@@ -1,0 +1,32 @@
+import { apiFetch } from '../identity';
+
+export interface TimehudleConnectionStatus {
+  connected: boolean;
+  timehudleEmail?: string;
+  timehudleName?: string;
+  connectedAt?: string;
+}
+
+export const getTimehudleStatus = async (): Promise<TimehudleConnectionStatus> => {
+  const res = await apiFetch('/v1/timehuddle/status');
+  if (!res.ok) throw new Error('Failed to fetch TimeHuddle status');
+  return res.json() as Promise<TimehudleConnectionStatus>;
+};
+
+export const connectTimehuddle = async (
+  token: string
+): Promise<{ connected: boolean; timehudleEmail: string; timehudleName: string }> => {
+  const res = await apiFetch('/v1/timehuddle/connect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+  const data = (await res.json()) as { connected: boolean; timehudleEmail: string; timehudleName: string; error?: string };
+  if (!res.ok) throw new Error(data.error ?? 'Connection failed');
+  return data;
+};
+
+export const disconnectTimehuddle = async (): Promise<void> => {
+  const res = await apiFetch('/v1/timehuddle/disconnect', { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to disconnect');
+};

--- a/timeharbourapp/app/dashboard/settings/page.tsx
+++ b/timeharbourapp/app/dashboard/settings/page.tsx
@@ -16,6 +16,7 @@ import {
   UserRoundCog,
   Upload,
   HelpCircle,
+  Link2,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -83,6 +84,7 @@ export default function SettingsPage() {
     { label: 'Edit Profile', icon: User, href: '/dashboard/settings/profile' },
     { label: 'Language', icon: Globe, href: '/dashboard/settings/language', comingSoon: true },
     { label: 'Timesheet Settings', icon: CalendarDays, href: '/dashboard/settings/timesheet' },
+    { label: 'TimeHuddle Connection', icon: Link2, href: '/dashboard/settings/timehuddle' },
   ];
 
   return (

--- a/timeharbourapp/app/dashboard/settings/timehuddle/page.tsx
+++ b/timeharbourapp/app/dashboard/settings/timehuddle/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ChevronLeft, Link2, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import { Button, Textarea, Text } from '@mieweb/ui';
+import {
+  getTimehudleStatus,
+  connectTimehuddle,
+  disconnectTimehuddle,
+  type TimehudleConnectionStatus,
+} from '@/TimeharborAPI/timehuddle';
+
+export default function TimehudlePage() {
+  const router = useRouter();
+
+  const [status, setStatus] = useState<TimehudleConnectionStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [token, setToken] = useState('');
+  const [connecting, setConnecting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const loadStatus = async () => {
+    try {
+      const s = await getTimehudleStatus();
+      setStatus(s);
+    } catch {
+      setStatus({ connected: false });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void loadStatus(); }, []);
+
+  const handleConnect = async () => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    setConnecting(true);
+    setMessage(null);
+    try {
+      const result = await connectTimehuddle(trimmed);
+      setStatus({ connected: true, timehudleEmail: result.timehudleEmail, timehudleName: result.timehudleName });
+      setToken('');
+      setMessage({ type: 'success', text: `Connected as ${result.timehudleEmail}` });
+    } catch (err: unknown) {
+      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Connection failed' });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    setMessage(null);
+    try {
+      await disconnectTimehuddle();
+      setStatus({ connected: false });
+      setMessage({ type: 'success', text: 'Disconnected from TimeHuddle' });
+    } catch (err: unknown) {
+      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Disconnect failed' });
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6 pb-8">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 pt-4">
+        <button
+          onClick={() => router.back()}
+          className="p-2 rounded-full hover:bg-muted transition-colors"
+          aria-label="Go back"
+        >
+          <ChevronLeft className="w-5 h-5" />
+        </button>
+        <div className="flex items-center gap-2">
+          <Link2 className="w-5 h-5 text-muted-foreground" />
+          <h1 className="text-xl font-bold">TimeHuddle Connection</h1>
+        </div>
+      </div>
+
+      <div className="px-4 space-y-6">
+        {/* Connection status */}
+        {loading ? (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <Text>Checking connection…</Text>
+          </div>
+        ) : status?.connected ? (
+          <div className="rounded-xl border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30 p-4 space-y-3">
+            <div className="flex items-center gap-2 text-green-700 dark:text-green-400">
+              <CheckCircle2 className="w-5 h-5" />
+              <Text className="font-semibold">Connected</Text>
+            </div>
+            {status.timehudleName && (
+              <Text className="text-sm">{status.timehudleName}</Text>
+            )}
+            {status.timehudleEmail && (
+              <Text className="text-sm text-muted-foreground">{status.timehudleEmail}</Text>
+            )}
+            {status.connectedAt && (
+              <Text className="text-xs text-muted-foreground">
+                Since {new Date(status.connectedAt).toLocaleDateString()}
+              </Text>
+            )}
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => void handleDisconnect()}
+              disabled={disconnecting}
+              isLoading={disconnecting}
+              loadingText="Disconnecting…"
+            >
+              Disconnect
+            </Button>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-border bg-muted/30 p-4 flex items-center gap-2 text-muted-foreground">
+            <XCircle className="w-5 h-5" />
+            <Text>Not connected</Text>
+          </div>
+        )}
+
+        {/* Connect form — always visible so user can reconnect */}
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Text className="font-semibold">
+              {status?.connected ? 'Reconnect with a new token' : 'Connect your TimeHuddle account'}
+            </Text>
+            <Text className="text-sm text-muted-foreground">
+              In TimeHuddle, go to <strong>Settings → API Tokens</strong>, generate a new token, and paste it below.
+            </Text>
+          </div>
+
+          <Textarea
+            placeholder="th_pat_…"
+            value={token}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setToken(e.target.value)}
+            rows={3}
+            className="font-mono text-sm"
+            aria-label="TimeHuddle personal access token"
+          />
+
+          <Button
+            onClick={() => void handleConnect()}
+            disabled={!token.trim() || connecting}
+            isLoading={connecting}
+            loadingText="Connecting…"
+            className="w-full"
+          >
+            Connect to TimeHuddle
+          </Button>
+        </div>
+
+        {/* Feedback message */}
+        {message && (
+          <div
+            className={`rounded-lg px-4 py-3 text-sm ${
+              message.type === 'success'
+                ? 'bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400'
+                : 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-400'
+            }`}
+            role="status"
+          >
+            {message.text}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/timeharbourapp/next.config.ts
+++ b/timeharbourapp/next.config.ts
@@ -44,6 +44,10 @@ const nextConfig: NextConfig = {
               destination: `${backendUrl}/api/timeharbor/:path*`,
             },
             {
+              source: '/api/v1/:path*',
+              destination: `${backendUrl}/v1/:path*`,
+            },
+            {
               source: '/api/health',
               destination: `${backendUrl}/api/health`,
             },

--- a/timeharbourapp/tests/e2e/timehuddle-connection.spec.ts
+++ b/timeharbourapp/tests/e2e/timehuddle-connection.spec.ts
@@ -1,0 +1,352 @@
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+/**
+ * TimeHuddle Connection E2E — Settings → TimeHuddle Connection page.
+ *
+ * All external API calls to /api/v1/timehuddle/* are intercepted via
+ * page.route() so tests never depend on a live TimeHuddle instance.
+ *
+ * What we verify:
+ *   1. Settings page lists the TimeHuddle Connection entry and navigates to it
+ *   2. Page shows "Not connected" when disconnected
+ *   3. Connect form is always visible (for first connect or reconnect)
+ *   4. Connect button is disabled when the token field is empty
+ *   5. Paste a valid token → API called → connected state shown (name + email)
+ *   6. Paste an invalid token → API returns error → error message shown
+ *   7. Disconnect button → API called → disconnected state restored
+ *   8. After disconnecting, connect form re-appears for a fresh token
+ *   9. Reconnect with a new token when already connected
+ */
+
+test.use({
+  viewport: { width: 390, height: 844 },
+  navigationTimeout: 30_000,
+});
+
+// ─── Route mock helpers ──────────────────────────────────────
+
+const VALID_TOKEN = 'th_pat_validtokenfortest';
+const INVALID_TOKEN = 'th_pat_badtoken';
+
+function mockDisconnected(page: Page) {
+  return page.route('**/api/v1/timehuddle/status', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ connected: false }) })
+  );
+}
+
+function mockConnected(page: Page, email = 'alice@timehuddle.io', name = 'Alice Timehuddle') {
+  return page.route('**/api/v1/timehuddle/status', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ connected: true, timehudleEmail: email, timehudleName: name, connectedAt: new Date().toISOString() }),
+    })
+  );
+}
+
+function mockConnectSuccess(page: Page, email = 'alice@timehuddle.io', name = 'Alice Timehuddle') {
+  return page.route('**/api/v1/timehuddle/connect', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ connected: true, timehudleEmail: email, timehudleName: name }),
+    })
+  );
+}
+
+function mockConnectFailure(page: Page, errorMessage = 'Invalid or expired token') {
+  return page.route('**/api/v1/timehuddle/connect', (route: Route) =>
+    route.fulfill({
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: errorMessage }),
+    })
+  );
+}
+
+function mockDisconnectSuccess(page: Page) {
+  return page.route('**/api/v1/timehuddle/disconnect', (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) })
+  );
+}
+
+// ─── Navigation helpers ──────────────────────────────────────
+
+async function goToTimehuddle(page: Page) {
+  await page.goto('/dashboard/settings/timehuddle');
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('heading', { name: 'TimeHuddle Connection' })).toBeVisible({ timeout: 10_000 });
+}
+
+// ═══════════════════════════════════════════════════════════
+// Navigation from Settings list
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle Connection entry', () => {
+  test('settings page lists TimeHuddle Connection and navigates to it', async ({ page }) => {
+    await mockDisconnected(page);
+
+    await page.goto('/dashboard/settings');
+    await page.waitForLoadState('networkidle');
+
+    const entry = page.getByText('TimeHuddle Connection');
+    await expect(entry).toBeVisible({ timeout: 10_000 });
+
+    await entry.click();
+    await expect(page).toHaveURL(/\/dashboard\/settings\/timehuddle/);
+    await expect(page.getByRole('heading', { name: 'TimeHuddle Connection' })).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Initial disconnected state
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: disconnected state', () => {
+  test('shows "Not connected" status and connect form', async ({ page }) => {
+    await mockDisconnected(page);
+    await goToTimehuddle(page);
+
+    // Status badge
+    await expect(page.getByText('Not connected')).toBeVisible();
+
+    // Connect form heading
+    await expect(page.getByText('Connect your TimeHuddle account')).toBeVisible();
+
+    // Token instructions
+    await expect(page.getByText(/Settings → API Tokens/)).toBeVisible();
+
+    // Token textarea with correct placeholder
+    const tokenInput = page.getByLabel('TimeHuddle personal access token');
+    await expect(tokenInput).toBeVisible();
+    await expect(tokenInput).toHaveAttribute('placeholder', 'th_pat_…');
+
+    // Connect button visible
+    await expect(page.getByRole('button', { name: 'Connect to TimeHuddle' })).toBeVisible();
+  });
+
+  test('connect button is disabled when token field is empty', async ({ page }) => {
+    await mockDisconnected(page);
+    await goToTimehuddle(page);
+
+    const connectBtn = page.getByRole('button', { name: 'Connect to TimeHuddle' });
+    await expect(connectBtn).toBeDisabled();
+  });
+
+  test('connect button remains disabled for whitespace-only input', async ({ page }) => {
+    await mockDisconnected(page);
+    await goToTimehuddle(page);
+
+    const tokenInput = page.getByLabel('TimeHuddle personal access token');
+    await tokenInput.fill('   ');
+
+    const connectBtn = page.getByRole('button', { name: 'Connect to TimeHuddle' });
+    await expect(connectBtn).toBeDisabled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Successful connect flow
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: connect flow', () => {
+  test('paste valid token → connects → shows connected state with name and email', async ({ page }) => {
+    await mockDisconnected(page);
+    await mockConnectSuccess(page);
+    await goToTimehuddle(page);
+
+    const tokenInput = page.getByLabel('TimeHuddle personal access token');
+    await tokenInput.fill(VALID_TOKEN);
+
+    // Connect button becomes enabled
+    const connectBtn = page.getByRole('button', { name: 'Connect to TimeHuddle' });
+    await expect(connectBtn).toBeEnabled();
+
+    await connectBtn.click();
+
+    // Connected status panel appears
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Alice Timehuddle')).toBeVisible();
+    await expect(page.getByText('alice@timehuddle.io', { exact: true }).first()).toBeVisible();
+
+    // Success feedback message
+    await expect(page.getByRole('status')).toContainText('Connected as alice@timehuddle.io');
+
+    // Token field cleared after successful connect
+    await expect(tokenInput).toHaveValue('');
+
+    // Disconnect button now visible
+    await expect(page.getByRole('button', { name: 'Disconnect' })).toBeVisible();
+  });
+
+  test('verify correct POST body is sent to connect endpoint', async ({ page }) => {
+    await mockDisconnected(page);
+
+    let capturedBody: Record<string, unknown> | null = null;
+    await page.route('**/api/v1/timehuddle/connect', async (route: Route) => {
+      capturedBody = JSON.parse(route.request().postData() ?? '{}') as Record<string, unknown>;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ connected: true, timehudleEmail: 'test@th.io', timehudleName: 'Test User' }),
+      });
+    });
+
+    await goToTimehuddle(page);
+    await page.getByLabel('TimeHuddle personal access token').fill(VALID_TOKEN);
+    await page.getByRole('button', { name: 'Connect to TimeHuddle' }).click();
+
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    expect(capturedBody).toEqual({ token: VALID_TOKEN });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Error handling
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: connection error', () => {
+  test('invalid token shows error message from API', async ({ page }) => {
+    await mockDisconnected(page);
+    await mockConnectFailure(page, 'Invalid or expired token');
+    await goToTimehuddle(page);
+
+    await page.getByLabel('TimeHuddle personal access token').fill(INVALID_TOKEN);
+    await page.getByRole('button', { name: 'Connect to TimeHuddle' }).click();
+
+    // Error feedback visible
+    const statusMsg = page.getByRole('status');
+    await expect(statusMsg).toBeVisible({ timeout: 10_000 });
+    await expect(statusMsg).toContainText('Invalid or expired token');
+
+    // Status still shows not connected
+    await expect(page.getByText('Not connected')).toBeVisible();
+
+    // Connect button re-enabled so user can retry
+    await expect(page.getByRole('button', { name: 'Connect to TimeHuddle' })).toBeEnabled();
+  });
+
+  test('network error shows generic fallback error message', async ({ page }) => {
+    await mockDisconnected(page);
+
+    await page.route('**/api/v1/timehuddle/connect', (route: Route) => route.abort('failed'));
+    await goToTimehuddle(page);
+
+    await page.getByLabel('TimeHuddle personal access token').fill(VALID_TOKEN);
+    await page.getByRole('button', { name: 'Connect to TimeHuddle' }).click();
+
+    const statusMsg = page.getByRole('status');
+    await expect(statusMsg).toBeVisible({ timeout: 10_000 });
+    // Some error message should appear (not empty)
+    const text = await statusMsg.textContent();
+    expect(text?.trim().length).toBeGreaterThan(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Disconnect flow
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: disconnect flow', () => {
+  test('already connected → disconnect → shows disconnected state', async ({ page }) => {
+    await mockConnected(page);
+    await mockDisconnectSuccess(page);
+    await goToTimehuddle(page);
+
+    // Verify connected state loaded
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Alice Timehuddle')).toBeVisible();
+    await expect(page.getByText('alice@timehuddle.io')).toBeVisible();
+
+    // Click disconnect
+    await page.getByRole('button', { name: 'Disconnect' }).click();
+
+    // Disconnected state appears
+    await expect(page.getByText('Not connected')).toBeVisible({ timeout: 10_000 });
+
+    // Success feedback
+    await expect(page.getByRole('status')).toContainText('Disconnected from TimeHuddle');
+
+    // Connect form re-appears with original heading
+    await expect(page.getByText('Connect your TimeHuddle account')).toBeVisible();
+  });
+
+  test('verify DELETE request sent to disconnect endpoint', async ({ page }) => {
+    await mockConnected(page);
+
+    let disconnectMethod: string | null = null;
+    await page.route('**/api/v1/timehuddle/disconnect', async (route: Route) => {
+      disconnectMethod = route.request().method();
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true }) });
+    });
+
+    await goToTimehuddle(page);
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Disconnect' }).click();
+
+    await expect(page.getByText('Not connected')).toBeVisible({ timeout: 10_000 });
+    expect(disconnectMethod).toBe('DELETE');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Already connected state rendering
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: already connected state', () => {
+  test('shows "Connected" badge, name, email, and connected-since date', async ({ page }) => {
+    await mockConnected(page);
+    await goToTimehuddle(page);
+
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Alice Timehuddle')).toBeVisible();
+    await expect(page.getByText('alice@timehuddle.io')).toBeVisible();
+    await expect(page.getByText(/Since/)).toBeVisible();
+  });
+
+  test('reconnect form shows "Reconnect with a new token" heading when connected', async ({ page }) => {
+    await mockConnected(page);
+    await goToTimehuddle(page);
+
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Reconnect with a new token')).toBeVisible();
+  });
+
+  test('can reconnect with a new token while already connected', async ({ page }) => {
+    await mockConnected(page);
+    await mockConnectSuccess(page, 'bob@timehuddle.io', 'Bob Timehuddle');
+    await goToTimehuddle(page);
+
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10_000 });
+
+    // Fill in a new token and reconnect
+    const tokenInput = page.getByLabel('TimeHuddle personal access token');
+    await tokenInput.fill('th_pat_newreplacementtoken');
+    await page.getByRole('button', { name: 'Connect to TimeHuddle' }).click();
+
+    // New account details reflected
+    await expect(page.getByText('Bob Timehuddle')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('bob@timehuddle.io', { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('status')).toContainText('Connected as bob@timehuddle.io');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Back navigation
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Settings — TimeHuddle: navigation', () => {
+  test('back button navigates away from the page', async ({ page }) => {
+    await mockDisconnected(page);
+    await page.goto('/dashboard/settings');
+    await page.waitForLoadState('networkidle');
+    await page.goto('/dashboard/settings/timehuddle');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { name: 'TimeHuddle Connection' })).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('main').getByRole('button', { name: 'Go back' }).click();
+
+    // Should have navigated away from the timehuddle page
+    await expect(page).not.toHaveURL(/\/dashboard\/settings\/timehuddle/);
+  });
+});

--- a/timeharbourapp/tests/e2e/timesheet-entry.spec.ts
+++ b/timeharbourapp/tests/e2e/timesheet-entry.spec.ts
@@ -706,7 +706,7 @@ test.describe('Timesheet: sync queue captures operations', () => {
     await page.goto('/dashboard/oplogs');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('CREATE', { exact: true })).toBeVisible();
+    await expect(page.getByText('CREATE', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('workSessions')).toBeVisible();
   });
 });


### PR DESCRIPTION
This pull request introduces TimeHuddle integration into the application, allowing users to connect, view status, and disconnect their TimeHuddle accounts from the dashboard settings. The main changes include backend submodule updates, API additions, UI updates, and proxy configuration.

**TimeHuddle integration and UI enhancements:**

* Added a new `timehuddle` API module with methods to get connection status, connect, and disconnect TimeHuddle accounts (`timeharbourapp/TimeharborAPI/timehuddle/index.ts`).
* Exported the new `timehuddle` API from the main API index for use throughout the app (`timeharbourapp/TimeharborAPI/index.ts`).

**Dashboard settings UI:**

* Added a "TimeHuddle Connection" option to the dashboard settings menu, including a dedicated settings page where users can connect/disconnect and view their connection status (`timeharbourapp/app/dashboard/settings/page.tsx`, `timeharbourapp/app/dashboard/settings/timehuddle/page.tsx`). 

**Backend and API proxy configuration:**

* Updated the backend submodule to the latest commit, ensuring compatibility with the new TimeHuddle endpoints (`timeharbor-timehuddle-backend`).
* Added a Next.js rewrite rule to proxy `/api/v1/*` requests to the backend, enabling the new TimeHuddle API endpoints to function in development and production (`timeharbourapp/next.config.ts`)