### PR TITLE
feat: implement OAuth flow for TimeHuddle connection and update conne…

### DIFF
--- a/timeharbourapp/TimeharborAPI/timehuddle/index.ts
+++ b/timeharbourapp/TimeharborAPI/timehuddle/index.ts
@@ -13,17 +13,11 @@ export const getTimehudleStatus = async (): Promise<TimehudleConnectionStatus> =
   return res.json() as Promise<TimehudleConnectionStatus>;
 };
 
-export const connectTimehuddle = async (
-  token: string
-): Promise<{ connected: boolean; timehudleEmail: string; timehudleName: string }> => {
-  const res = await apiFetch('/v1/timehuddle/connect', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ token }),
-  });
-  const data = (await res.json()) as { connected: boolean; timehudleEmail: string; timehudleName: string; error?: string };
-  if (!res.ok) throw new Error(data.error ?? 'Connection failed');
-  return data;
+export const startTimehudleOAuth = async (): Promise<string> => {
+  const res = await apiFetch('/v1/timehuddle/oauth/start');
+  if (!res.ok) throw new Error('Failed to start TimeHuddle OAuth');
+  const data = await res.json() as { authorizeUrl: string };
+  return data.authorizeUrl;
 };
 
 export const disconnectTimehuddle = async (): Promise<void> => {

--- a/timeharbourapp/app/dashboard/settings/timehuddle/page.tsx
+++ b/timeharbourapp/app/dashboard/settings/timehuddle/page.tsx
@@ -1,23 +1,22 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { ChevronLeft, Link2, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
-import { Button, Textarea, Text } from '@mieweb/ui';
+import { Button, Text } from '@mieweb/ui';
 import {
   getTimehudleStatus,
-  connectTimehuddle,
   disconnectTimehuddle,
+  startTimehudleOAuth,
   type TimehudleConnectionStatus,
 } from '@/TimeharborAPI/timehuddle';
 
 export default function TimehudlePage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const [status, setStatus] = useState<TimehudleConnectionStatus | null>(null);
   const [loading, setLoading] = useState(true);
-  const [token, setToken] = useState('');
-  const [connecting, setConnecting] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -32,21 +31,32 @@ export default function TimehudlePage() {
     }
   };
 
-  useEffect(() => { void loadStatus(); }, []);
+  useEffect(() => {
+    // Handle OAuth callback result passed as query params
+    const connected = searchParams.get('connected');
+    const error = searchParams.get('error');
+    if (connected === 'true') {
+      setMessage({ type: 'success', text: 'Successfully connected to TimeHuddle!' });
+    } else if (error) {
+      const msgs: Record<string, string> = {
+        invalid_state: 'Connection request expired or was tampered with. Please try again.',
+        token_exchange_failed: 'Could not complete sign-in with TimeHuddle. Please try again.',
+        access_denied: 'You declined the TimeHuddle connection request.',
+      };
+      setMessage({ type: 'error', text: msgs[error] ?? `Connection failed: ${error}` });
+    }
+    void loadStatus();
+  }, [searchParams]);
+
+  const [connecting, setConnecting] = useState(false);
 
   const handleConnect = async () => {
-    const trimmed = token.trim();
-    if (!trimmed) return;
     setConnecting(true);
-    setMessage(null);
     try {
-      const result = await connectTimehuddle(trimmed);
-      setStatus({ connected: true, timehudleEmail: result.timehudleEmail, timehudleName: result.timehudleName });
-      setToken('');
-      setMessage({ type: 'success', text: `Connected as ${result.timehudleEmail}` });
+      const authorizeUrl = await startTimehudleOAuth();
+      window.location.href = authorizeUrl;
     } catch (err: unknown) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Connection failed' });
-    } finally {
+      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to start connection' });
       setConnecting(false);
     }
   };
@@ -124,34 +134,27 @@ export default function TimehudlePage() {
           </div>
         )}
 
-        {/* Connect form — always visible so user can reconnect */}
-        <div className="space-y-4">
+        {/* Connect / reconnect */}
+        <div className="space-y-3">
           <div className="space-y-1">
             <Text className="font-semibold">
-              {status?.connected ? 'Reconnect with a new token' : 'Connect your TimeHuddle account'}
+              {status?.connected ? 'Reconnect with TimeHuddle' : 'Connect your TimeHuddle account'}
             </Text>
             <Text className="text-sm text-muted-foreground">
-              In TimeHuddle, go to <strong>Settings → API Tokens</strong>, generate a new token, and paste it below.
+              You will be taken to TimeHuddle to sign in and authorise the connection.
             </Text>
           </div>
 
-          <Textarea
-            placeholder="th_pat_…"
-            value={token}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setToken(e.target.value)}
-            rows={3}
-            className="font-mono text-sm"
-            aria-label="TimeHuddle personal access token"
-          />
-
           <Button
             onClick={() => void handleConnect()}
-            disabled={!token.trim() || connecting}
+            className="w-full"
+            disabled={connecting}
             isLoading={connecting}
             loadingText="Connecting…"
-            className="w-full"
+            aria-label="Connect to TimeHuddle via OAuth"
           >
-            Connect to TimeHuddle
+            <Link2 className="w-4 h-4 mr-2" />
+            {status?.connected ? 'Reconnect with TimeHuddle' : 'Connect with TimeHuddle'}
           </Button>
         </div>
 
@@ -172,3 +175,4 @@ export default function TimehudlePage() {
     </div>
   );
 }
+


### PR DESCRIPTION
This pull request updates the TimeHuddle integration flow to use OAuth instead of requiring users to manually enter a personal access token. The UI and API calls have been refactored to support this new, more user-friendly, and secure authentication process.

**TimeHuddle OAuth Integration:**

* Replaced the manual token entry flow with an OAuth-based connection. The `connectTimehuddle` API method and related UI for token input were removed, and a new `startTimehudleOAuth` API method was added to initiate the OAuth process and redirect the user to TimeHuddle for authorization. 

**UI and UX Improvements:**

* Updated the connection UI to remove the token input field and instead provide a single "Connect with TimeHuddle" button, which starts the OAuth flow. The button text and description now clearly indicate the OAuth-based process.
* Improved handling of OAuth callback results: the page now parses query parameters for connection success or error messages and displays appropriate feedback to the user.

**Code Cleanup:**

* Removed unused imports and state variables related to the old token-based connection flow. 